### PR TITLE
Add support for running a JQ over the output

### DIFF
--- a/src/dotnet-x/JsonCommandSettings.cs
+++ b/src/dotnet-x/JsonCommandSettings.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Devlooped;
+
+public class JsonCommandSettings : CommandSettings
+{
+    [Description("Filter JSON output using a jq expression")]
+    [CommandOption("--jq [expression]")]
+    public FlagValue<string> JQ { get; set; } = new();
+
+    [Description("Output as JSON. Implied when using --jq")]
+    [DefaultValue(false)]
+    [CommandOption("--json")]
+    public bool Json { get; set; }
+
+    [Description("Disable colors when rendering JSON to the console")]
+    [DefaultValue(false)]
+    [CommandOption("--monochrome")]
+    public bool Monochrome { get; set; }
+
+    public override ValidationResult Validate()
+    {
+        if (JQ.IsSet && !string.IsNullOrEmpty(JQ.Value))
+            Json = true;
+
+        return base.Validate();
+    }
+}

--- a/src/dotnet-x/JsonOutput.cs
+++ b/src/dotnet-x/JsonOutput.cs
@@ -1,0 +1,159 @@
+﻿using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using Spectre.Console.Json;
+
+namespace Devlooped;
+
+static class JsonOutput
+{
+    static readonly JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
+    {
+        Converters =
+        {
+            new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)
+        },
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true,
+    };
+
+    public static int RenderJson<T>(this IAnsiConsole console, T value, JsonCommandSettings settings, CancellationToken cancellation)
+        => RenderJson(console, value, settings.JQ, settings.Monochrome, cancellation);
+
+    public static int RenderJson<T>(this IAnsiConsole console, T value, FlagValue<string> jq, bool monochrome = false, CancellationToken cancellation = default)
+        => RenderJson(console, value, jq.IsSet ? jq.Value : default, monochrome, cancellation);
+
+    public static int RenderJson<T>(this IAnsiConsole console, T value, string? jq = default, bool monochrome = false, CancellationToken cancellation = default)
+    {
+        var json = JsonSerializer.Serialize(value, options);
+        if (string.IsNullOrWhiteSpace(jq))
+        {
+            WriteJson(console, monochrome, json);
+            return 0;
+        }
+        return RenderJson(console, json, jq, monochrome, cancellation);
+    }
+
+    public static int RenderJson(this IAnsiConsole console, string json, JsonCommandSettings settings, CancellationToken cancellation = default)
+    {
+        if (settings.JQ.IsSet)
+            return RenderJson(console, json, settings.JQ.Value, settings.Monochrome, cancellation);
+
+        WriteJson(console, settings.Monochrome, json);
+        return 0;
+    }
+
+    public static int RenderJson(this IAnsiConsole console, string json, FlagValue<string> jq, bool monochrome = false, CancellationToken cancellation = default)
+    {
+        if (!jq.IsSet || string.IsNullOrWhiteSpace(jq.Value))
+        {
+            WriteJson(console, monochrome, json);
+            return 0;
+        }
+        return RenderJson(console, json, jq.Value, monochrome, cancellation);
+    }
+
+    public static int RenderJson(this IAnsiConsole console, string json, string jq, bool monochrome = false, CancellationToken cancellation = default)
+    {
+        var info = new ProcessStartInfo(JQ.Path)
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+        };
+
+        info.StandardInputEncoding = info.StandardErrorEncoding = info.StandardOutputEncoding = Encoding.UTF8;
+        info.ArgumentList.Add("-r");
+        info.ArgumentList.Add("--monochrome-output");
+
+        var normalized = jq.ReplaceLineEndings().Trim();
+        if (normalized.Contains(Environment.NewLine))
+        {
+            // get sha256 of the query, make a temp file with a windows-friendly filename derived from it
+            // and persist the query. use the temp file as the query file input instead of a simple arg
+            var hash = BitConverter.ToString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)));
+            var queryFile = Path.Combine(Path.GetTempPath(), $"{hash}.jq");
+            if (!File.Exists(queryFile))
+                File.WriteAllText(queryFile, normalized);
+
+            info.ArgumentList.Add("-f");
+            info.ArgumentList.Add(queryFile);
+        }
+        else
+        {
+            info.ArgumentList.Add(jq.Trim());
+        }
+
+        var process = Process.Start(info);
+        if (process == null)
+        {
+            console.MarkupLine($":cross_mark: Could not start JQ from {JQ.Path}");
+            return -1;
+        }
+
+        if (!process.HasExited)
+        {
+            try
+            {
+                using var writer = process.StandardInput;
+                writer.Write(json);
+                writer.Close();
+            }
+            catch (IOException ioe)
+            {
+                console.WriteException(ioe);
+                // The process might exit due to parsing of the query
+            }
+        }
+
+        while (!cancellation.IsCancellationRequested && !process.WaitForExit(100))
+        {
+        }
+
+        if (cancellation.IsCancellationRequested)
+        {
+            if (!process.HasExited)
+                process.Kill();
+
+            return -1;
+        }
+
+        var output = process.ExitCode != 0 ?
+            process.StandardError.ReadToEnd() :
+            process.StandardOutput.ReadToEnd();
+
+        if (!string.IsNullOrWhiteSpace(output))
+        {
+            WriteJson(console, monochrome, output.Trim());
+        }
+
+        return process.ExitCode;
+    }
+
+    static void WriteJson(IAnsiConsole console, bool monochrome, string json)
+    {
+        json = json.Trim();
+        if (monochrome)
+        {
+            console.Write(json);
+        }
+        else
+        {
+            try
+            {
+                console.Write(new JsonText(json));
+            }
+            catch
+            {
+                console.Write(json);
+            }
+        }
+    }
+}

--- a/src/dotnet-x/docs/post.md
+++ b/src/dotnet-x/docs/post.md
@@ -10,7 +10,10 @@ ARGUMENTS:
     <TEXT>    Text to post
 
 OPTIONS:
-    -h, --help             Prints help information                              
-    -m, --media <MEDIA>    Zero or more media files to attach to the post (.jpg,
-                           .jpeg, .png, .gif, .webp, .mp4, .mov)                
+    -h, --help               Prints help information                            
+        --jq [EXPRESSION]    Filter JSON output using a jq expression           
+        --json               Output as JSON. Implied when using --jq            
+        --monochrome         Disable colors when rendering JSON to the console  
+    -m, --media <MEDIA>      Zero or more media files to attach to the post     
+                             (.jpg, .jpeg, .png, .gif, .webp, .mp4, .mov)       
 ```


### PR DESCRIPTION
Also render by default a nice link to the posted entry, or alternatively the provided JQ.

To render just the post ID in monochrome, for example, you can run: `post 'Testing X CLI' --jq .data.id --monochrome`