### PR TITLE
Rename to dotnet-xcli to circumvent dumb nuget.org rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 ![Icon](assets/img/logo.png) A CLI for X
 ============
 
-[![Version](https://img.shields.io/nuget/vpre/dotnet-x.svg?color=royalblue)](https://www.nuget.org/packages/dotnet-x)
-[![Downloads](https://img.shields.io/nuget/dt/dotnet-x.svg?color=green)](https://www.nuget.org/packages/dotnet-x)
+[![Version](https://img.shields.io/nuget/vpre/dotnet-xcli.svg?color=royalblue)](https://www.nuget.org/packages/dotnet-xcli)
+[![Downloads](https://img.shields.io/nuget/dt/dotnet-xcli.svg?color=green)](https://www.nuget.org/packages/dotnet-xcli)
 [![License](https://img.shields.io/github/license/devlooped/dotnet-x.svg?color=blue)](https://github.com//devlooped/dotnet-x/blob/main/license.txt)
 [![Build](https://github.com/devlooped/dotnet-x/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/devlooped/dotnet-x/actions/workflows/build.yml)
 

--- a/src/dotnet-x/Auth/LoginCommand.cs
+++ b/src/dotnet-x/Auth/LoginCommand.cs
@@ -26,7 +26,7 @@ namespace Devlooped.Auth;
           X_ConsumerKey: ${{ secrets.X_CONSUMER_KEY }}
           X_ConsumerSecret: ${{ secrets.X_CONSUMER_SECRET }}
         run: |
-          dotnet tool update -g dotnet-x 
+          dotnet tool update -g dotnet-xcli 
           x post "Hello, world!" --media image.png
     """)]
 public class LoginCommand(ICommandApp app, ICredentialStore store, IConfiguration configuration) : AsyncCommand<LoginCommand.LoginSettings>

--- a/src/dotnet-x/docs/auth-login.md
+++ b/src/dotnet-x/docs/auth-login.md
@@ -22,7 +22,7 @@ For example, to use x in GitHub Actions:
       X_ConsumerKey: ${{ secrets.X_CONSUMER_KEY }}
       X_ConsumerSecret: ${{ secrets.X_CONSUMER_SECRET }}
     run: |
-      dotnet tool update -g dotnet-x 
+      dotnet tool update -g dotnet-xcli 
       x post "Hello, world!" --media image.png
 
 USAGE:

--- a/src/dotnet-x/dotnet-x.csproj
+++ b/src/dotnet-x/dotnet-x.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Devlooped</RootNamespace>
 
-    <PackageId>dotnet-x</PackageId>
+    <PackageId>dotnet-xcli</PackageId>
     <Description>X CLI: manage posts from the command prompt</Description>
     <ToolCommandName>x</ToolCommandName>
   </PropertyGroup>


### PR DESCRIPTION
Reported as a bug at https://github.com/NuGet/NuGetGallery/issues/10381, but not holding my breath.